### PR TITLE
Implemented Android builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: sha1sum main.jks
       - name: Capture working directory
         id: pwd
-        run: pwd
+        run: echo "::set-output name=wd::$(pwd)"
       - name: Debug the pwd step
         run: echo "${{ toJSON(steps.pwd) }}"
       - name: Build APK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,11 @@ on:
       - master
       - dev-ci-*
 
+env:
+  APP_ID: "divvun.org.satni"
+
 jobs:
-  apk_build:
+  android_build:
     name: Build Android
     runs-on: ubuntu-latest
     env:
@@ -56,3 +59,24 @@ jobs:
         with:
           name: aab
           path: build/app/outputs/bundle/release/app-release.aab
+
+  android_push:
+    name: Deploy Android
+    needs:
+      - android_build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download the AAB
+        uses: actions/download-artifact@v2
+        with:
+          name: aab
+      - name: DEBUG echo file structure
+        run: ls -R aab
+      - name: Push the AAB to Google Play
+        uses: r0adkll/upload-google-play@v1
+        with:
+          packageName: ${{ env.APP_ID }}
+          releaseFiles: aab/app-release.aab
+          track: internal
+          serviceAccountJson: "{}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,6 @@ jobs:
         uses: r0adkll/upload-google-play@v1
         with:
           packageName: ${{ env.APP_ID }}
-          releaseFiles: aab/app-release.aab
+          releaseFiles: app-release.aab
           track: internal
-          serviceAccountJson: "{}"
+          serviceAccountJson: "${{ secrets.SERVICE_ACCOUNT }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,15 @@ jobs:
         run: flutter --version
       - name: Build APK
         run: flutter build apk
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: apk
+          path: build/app/outputs/flutter-apk/app-release.apk
       - name: Build AAB
         run: flutter build appbundle
-      - name: List build directory; have to find artefacts
-        run: ls -al
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: aab
+          path: build/app/outputs/bundle/release/app-release.aab

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       keystore: main.jks
+      version_code: ${{ github.run_number }}+${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v2
       - name: Install a JDK
@@ -46,14 +47,14 @@ jobs:
           sed -e "s|c5b6486b-091e-42cd-a253-2f62f06ac970|$KSK|g" -E -i android/key.properties
           sed -e "s|eed0bb70-0e0e-466a-afeb-16c49c9c22de|$WD/$KS|g" -E -i android/key.properties
       - name: Build APK
-        run: flutter build apk
+        run: flutter build apk --build-number "${{ env.version_code }}"
       - name: Upload APK artifact
         uses: actions/upload-artifact@v2
         with:
           name: apk
           path: build/app/outputs/flutter-apk/app-release.apk
       - name: Build AAB
-        run: flutter build appbundle
+        run: flutter build appbundle --build-number "${{ env.version_code }}"
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ jobs:
   apk_build:
     name: Build Android
     runs-on: ubuntu-latest
+    env:
+      keystore: main.jks
     steps:
       - uses: actions/checkout@v2
       # - name: Install a JDK
@@ -26,14 +28,24 @@ jobs:
       # - name: Verify flutter version
       #   run: flutter --version
       - name: Install keystore
-        run: echo ${{ secrets.KEYSTORE }} | base64 -d > main.jks
+        run: echo ${{ secrets.KEYSTORE }} | base64 -d > ${{ env.keystore }}
       - name: Verify Keystore contents
         run: sha1sum main.jks
       - name: Capture working directory
         id: pwd
         run: echo "::set-output name=wd::$(pwd)"
+      - name: Inject key information
+        env:
+          KSK: ${{ secrets.KEYSTORE_KEY }}
+          WD: ${{ steps.pwd.outputs.wd }}
+          KS: ${{ env.keystore }}
+        run: |
+          sed -e "s|c5b6486b-091e-42cd-a253-2f62f06ac970|$KSK|g" -E -i android/key.properties
+          sed -e "s|eed0bb70-0e0e-466a-afeb-16c49c9c22de|$WD/$KS|g" -E -i android/key.properties
       - name: Debug the pwd step
         run: echo "${{ toJSON(steps.pwd) }}"
+      - name: Verify non-secret part of key.properties
+        run: tail -n1 android/key.properties
       - name: Build APK
         run: flutter build apk
       - name: Upload APK artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       keystore: main.jks
-      version_code: ${{ github.run_number }}+${{ github.run_attempt }}
+      version_code: ${{ github.run_number }}
     steps:
       - uses: actions/checkout@v2
       - name: Install a JDK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,10 @@ jobs:
         run: flutter config --no-analytics
       - name: Verify flutter version
         run: flutter --version
+      - name: Install keystore
+        run: echo ${{ secrets.KEYSTORE }} | base64 -d > main.jks
+      - name: Verify Keystore contents
+        run: sha1sum main.jks
       - name: Build APK
         run: flutter build apk
       - name: Upload APK artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,12 +72,11 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: aab
-      - name: DEBUG echo file structure
-        run: ls -R
       - name: Push the AAB to Google Play
         uses: r0adkll/upload-google-play@v1
         with:
           packageName: ${{ env.APP_ID }}
           releaseFiles: app-release.aab
           track: internal
+          status: draft
           serviceAccountJsonPlainText: "${{ secrets.SERVICE_ACCOUNT }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,20 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install a JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: '11'
-      - name: Install Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '2.10.2'
-          channel: 'stable'
-      - name: Disable Google phone-home
-        run: flutter config --no-analytics
-      - name: Verify flutter version
-        run: flutter --version
+      # - name: Install a JDK
+      #   uses: actions/setup-java@v2
+      #   with:
+      #     distribution: 'zulu'
+      #     java-version: '11'
+      # - name: Install Flutter
+      #   uses: subosito/flutter-action@v2
+      #   with:
+      #     flutter-version: '2.10.2'
+      #     channel: 'stable'
+      # - name: Disable Google phone-home
+      #   run: flutter config --no-analytics
+      # - name: Verify flutter version
+      #   run: flutter --version
       - name: Install keystore
         run: echo ${{ secrets.KEYSTORE }} | base64 -d > main.jks
       - name: Verify Keystore contents
@@ -33,7 +33,7 @@ jobs:
         id: pwd
         run: pwd
       - name: Debug the pwd step
-        run: echo "${{ steps.pwd }}"
+        run: echo "${{ toJSON(steps.pwd) }}"
       - name: Build APK
         run: flutter build apk
       - name: Upload APK artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: Main buildchain
+on:
+  push:
+    branches:
+      - master
+      - dev-ci-*
+
+jobs:
+  apk_build:
+    name: Build APK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install a JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '2.10.2'
+          channel: 'stable'
+      - name: Disable Google phone-home
+        run: flutter config --no-analytics
+      - name: Verify flutter version
+        run: flutter --version
+      - name: Build APK
+        run: flutter build apk
+      - name: Build AAB
+        run: flutter build appbundle
+      - name: List build directory; have to find artefacts
+        run: ls -al

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   apk_build:
-    name: Build APK
+    name: Build Android
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -29,6 +29,11 @@ jobs:
         run: echo ${{ secrets.KEYSTORE }} | base64 -d > main.jks
       - name: Verify Keystore contents
         run: sha1sum main.jks
+      - name: Capture working directory
+        id: pwd
+        run: pwd
+      - name: Debug the pwd step
+        run: echo "${{ steps.pwd }}"
       - name: Build APK
         run: flutter build apk
       - name: Upload APK artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,20 +13,20 @@ jobs:
       keystore: main.jks
     steps:
       - uses: actions/checkout@v2
-      # - name: Install a JDK
-      #   uses: actions/setup-java@v2
-      #   with:
-      #     distribution: 'zulu'
-      #     java-version: '11'
-      # - name: Install Flutter
-      #   uses: subosito/flutter-action@v2
-      #   with:
-      #     flutter-version: '2.10.2'
-      #     channel: 'stable'
-      # - name: Disable Google phone-home
-      #   run: flutter config --no-analytics
-      # - name: Verify flutter version
-      #   run: flutter --version
+      - name: Install a JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '2.10.2'
+          channel: 'stable'
+      - name: Disable Google phone-home
+        run: flutter config --no-analytics
+      - name: Verify flutter version
+        run: flutter --version
       - name: Install keystore
         run: echo ${{ secrets.KEYSTORE }} | base64 -d > ${{ env.keystore }}
       - name: Verify Keystore contents
@@ -42,10 +42,6 @@ jobs:
         run: |
           sed -e "s|c5b6486b-091e-42cd-a253-2f62f06ac970|$KSK|g" -E -i android/key.properties
           sed -e "s|eed0bb70-0e0e-466a-afeb-16c49c9c22de|$WD/$KS|g" -E -i android/key.properties
-      - name: Debug the pwd step
-        run: echo "${{ toJSON(steps.pwd) }}"
-      - name: Verify non-secret part of key.properties
-        run: tail -n1 android/key.properties
       - name: Build APK
         run: flutter build apk
       - name: Upload APK artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,4 +79,4 @@ jobs:
           packageName: ${{ env.APP_ID }}
           releaseFiles: app-release.aab
           track: internal
-          serviceAccountJson: "${{ secrets.SERVICE_ACCOUNT }}"
+          serviceAccountJsonPlainText: "${{ secrets.SERVICE_ACCOUNT }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           name: aab
       - name: DEBUG echo file structure
-        run: ls -R aab
+        run: ls -R
       - name: Push the AAB to Google Play
         uses: r0adkll/upload-google-play@v1
         with:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,6 +21,12 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
@@ -50,11 +56,20 @@ android {
         versionName flutterVersionName
     }
 
+    signingConfigs {
+       release {
+           keyAlias keystoreProperties['keyAlias']
+           keyPassword keystoreProperties['keyPassword']
+           storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+           storePassword keystoreProperties['storePassword']
+       }
+    }
     buildTypes {
-        release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
+        debug {
             signingConfig signingConfigs.debug
+        }
+        release {
+            signingConfig signingConfigs.release
         }
     }
 }

--- a/android/key.properties
+++ b/android/key.properties
@@ -1,0 +1,4 @@
+storePassword=c5b6486b-091e-42cd-a253-2f62f06ac970
+keyPassword=c5b6486b-091e-42cd-a253-2f62f06ac970
+keyAlias=satni-upload
+storeFile=eed0bb70-0e0e-466a-afeb-16c49c9c22de


### PR DESCRIPTION
This PR creates a GitHub Actions Workflow which, in two stages, builds and then publishes the android application to the Google Play store (as a draft; manual action is still needed to actually publish the app).

While Flutter itself advises against committing the `android/key.properties` file to source control, the file contains no secret information; the UUID-strings are replaced during the CI run with the actual secrets.

Note; GitHub does not seem to have a function to auto-squash the branch before a merge. Let me know if you want me to compress the history to be less noisy (and less swear-y).